### PR TITLE
Docker build & push for Github Actions [WIK-217]

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,123 @@
+name: Docker
+
+# limit concurrency
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#examples-using-concurrency-and-the-default-behavior
+concurrency: docker_wikiteq_main
+
+on:
+  push:
+    # Only activate for `master` branch
+    branches:
+      - master
+    # Plus for all tags
+    tags:
+      - '*'
+
+  # Plus for any pull-requests
+  pull_request:
+
+env:
+  IMAGE_NAME: mediawiki
+
+jobs:
+  # Push image to GitHub Packages.
+  # The image tag pattern is:
+  # for pull-requests: <MW_CORE_VERSION>-<DATE>-<PR_NUMBER>, eg: 1.35.2-20210125-25
+  # for tags: <TAG>
+  # for `master` branch: latest
+  # <MW_CORE_VERSION> being parsed from the Dockerfile
+  push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Generate tags
+        id: generate
+        run: |
+
+          # Image ID
+          IMAGE_ID=ghcr.io/wikiteq/mediawiki
+
+          # Date
+          BDATE=$(date +%Y%m%d)
+
+          # Extract MW version from Dockerfile
+          MEDIAWIKI_VERSION=$(sed -nr 's/MW_CORE_VERSION\=([0-9\.]+)/\1/p' Dockerfile | sed "s/ \\\//" | sed "s/\t//")
+
+          # Change all uppercase to lowercase, just in case
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version and use it as suffix for version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # For pull requests just extract the PR number
+          [ "${{ github.event_name }}" == "pull_request" ] && VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\)/merge,\1,')
+
+          # Append version
+          [ "${{ github.event_name }}" == "pull_request" ] && VERSION=$MEDIAWIKI_VERSION-$BDATE-$VERSION
+
+          # Strip "v" prefix from tag name if it's a tag
+          # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention if it's a master branch build
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          # Compose REGISTRY_TAGS variable
+          REGISTRY_TAGS=$IMAGE_ID:$VERSION
+
+          # For master branch also supply an extra tag
+          [ "$VERSION" == "latest" ] && REGISTRY_TAGS=$REGISTRY_TAGS,$IMAGE_ID:$MEDIAWIKI_VERSION-$BDATE-$(git rev-parse --short HEAD)
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          echo REGISTRY_TAGS=$REGISTRY_TAGS
+          echo headref=${{ github.head_ref }}
+
+          echo "Final image tag to be pushed:"
+          echo $REGISTRY_TAGS
+          echo "::set-output name=REGISTRY_TAGS::$REGISTRY_TAGS"
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          tags: ${{ steps.generate.outputs.REGISTRY_TAGS }}
+      -
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Image tags debug
+        run: echo ${{ steps.generate.outputs.REGISTRY_TAGS }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -105,7 +105,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: false
+          push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           tags: ${{ steps.generate.outputs.REGISTRY_TAGS }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,7 +24,7 @@ jobs:
   # The image tag pattern is:
   # for pull-requests: <MW_CORE_VERSION>-<DATE>-<PR_NUMBER>, eg: 1.35.2-20210125-25
   # for tags: <TAG>
-  # for `master` branch: latest + <MW_CORE_VERSION>-<DATE>-<SHA>
+  # for `master` branch: latest + <MW_VERSION>-latest + <MW_CORE_VERSION>-<DATE>-<SHA>
   # <MW_CORE_VERSION> being parsed from the Dockerfile
   push:
     runs-on: ubuntu-latest
@@ -67,8 +67,8 @@ jobs:
           # Compose REGISTRY_TAGS variable
           REGISTRY_TAGS=$IMAGE_ID:$VERSION
 
-          # For master branch also supply an extra tag
-          [ "$VERSION" == "latest" ] && REGISTRY_TAGS=$REGISTRY_TAGS,$IMAGE_ID:$MEDIAWIKI_VERSION-$BDATE-$(git rev-parse --short HEAD)
+          # For master branch also supply an extra tag: <MW_VERSION>-latest,<MW_VERSION>-<DATE>-<SHA>
+          [ "$VERSION" == "latest" ] && REGISTRY_TAGS=$REGISTRY_TAGS,$IMAGE_ID:$MEDIAWIKI_VERSION-latest,$IMAGE_ID:$MEDIAWIKI_VERSION-$BDATE-$(git rev-parse --short HEAD)
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,7 +24,7 @@ jobs:
   # The image tag pattern is:
   # for pull-requests: <MW_CORE_VERSION>-<DATE>-<PR_NUMBER>, eg: 1.35.2-20210125-25
   # for tags: <TAG>
-  # for `master` branch: latest
+  # for `master` branch: latest + <MW_CORE_VERSION>-<DATE>-<SHA>
   # <MW_CORE_VERSION> being parsed from the Dockerfile
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `.github/workflows/docker-image.yml`:

- the workflow parses `MW_CORE_VERSION` ENV from the `Dockerfile`
- the workflow builds the image and pushed the resulting image to the Github Registry as `mediawiki` package (`ghcr.io/wikiteq/mediawiki`)
- the workflow uses the following tagging convention:
  - **Pull-requests**: `<MW_CORE_VERSION>-<DATE>-<PR_NUMBER>`, eg: `1.35.2-20210125-25`
  - **Tags**: `<TAG>`, eg: `MYTESTTAG`
  - **master**: `latest` + `<MW_CORE_VERSION>-<DATE>-<SHA>`
- the workflow runs for pull-requests and pushed to the master branch
- the workflow is supplied with cache for docker layers and is limit to 1 active job at the time
- the average fresh build takes 20-30 minutes, the cached build takes 3-5 minutes