### PR TITLE
Adds Monit to watch & notify about low disk space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,19 @@ RUN set -x; \
 	&& yum-config-manager --enable remi-php74 \
 	&& yum -y update \
 	&& yum -y install httpd php php-cli php-mysqlnd php-gd php-mbstring php-xml php-intl php-opcache php-pecl-apcu php-redis \
-		git composer mysql wget unzip ImageMagick python-pygments ssmtp patch vim mc ffmpeg \
+		git composer mysql wget unzip ImageMagick python-pygments ssmtp patch vim mc ffmpeg curl monit \
 	&& mkdir -p $MW_ORIGIN_FILES \
 	&& mkdir -p $MW_HOME
+
+# Install Monit & monit-slack-hook to watch low disk space
+# The hook will do nothing unless the $MONIT_SLACK_HOOK is provided
+
+COPY monit-slack.sh /monit-slack.sh
+
+RUN set -x; \
+	chmod +x /monit-slack.sh \
+	&& echo $'set httpd port 2812 and\n\tuse address localhost\n\tallow localhost' >> /etc/monitrc \
+	&& echo $'check filesystem rootfs with path /\n\tif SPACE usage > 90% then exec "/monit-slack.sh"' > /etc/monit.d/hdd
 
 FROM base as source
 

--- a/monit-slack.sh
+++ b/monit-slack.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+URL=$MONIT_SLACK_HOOK
+
+if [ -z "$URL" ]
+  then
+    # Do nothing, exit silently
+    exit 0
+fi
+
+COLOR=${MONIT_COLOR:-$([[ $MONIT_EVENT == *"Exists"* || $MONIT_EVENT == *"succeeded"*  ]] && echo good || echo danger)}
+ICON=${MONIT_COLOR:-$([[ $MONIT_EVENT == *"Exists"* || $MONIT_EVENT == *"succeeded"* ]] && echo ✅ || echo ⚠️)}
+TEXT=$(echo -e "$ICON $MONIT_EVENT: $MONIT_DESCRIPTION" | python3 -c "import json,sys;print(json.dumps(sys.stdin.read()))")
+
+PAYLOAD="{
+  \"attachments\": [
+    {
+      \"text\": $TEXT,
+      \"color\": \"$COLOR\",
+      \"mrkdwn_in\": [\"text\"],
+      \"fields\": [
+        { \"title\": \"Host\", \"value\": \"$MONIT_HOST\", \"short\": true },
+        { \"title\": \"Service\", \"value\": \"$MONIT_SERVICE\", \"short\": true },
+        { \"title\": \"Date\", \"value\": \"$MONIT_DATE\", \"short\": true }
+      ]
+    }
+  ]
+}"
+
+curl -s -X POST --data-urlencode "payload=$PAYLOAD" $URL

--- a/run-apache.sh
+++ b/run-apache.sh
@@ -267,6 +267,10 @@ run_autoupdate () {
     echo Auto-update completed
 }
 
+run_monit () {
+  monit -I -c /etc/monitrc
+}
+
 ########## Run maintenance scripts ##########
 if [ "$MW_AUTOUPDATE" = true ]; then
     run_autoupdate &
@@ -275,6 +279,12 @@ else
     jobrunner &
     transcoder &
     sitemapgen &
+fi
+
+########## Run Monit ##########
+if [ -n "$MONIT_SLACK_HOOK" ]; then
+    echo "Starting monit.."
+    run_monit &
 fi
 
 # Make sure we're not confused by old, incompletely-shutdown httpd


### PR DESCRIPTION
* Introduces new `MONIT_SLACK_HOOK` env variable intended to contain a Slack hook URL to be used as notification channel for Monit. 
* The change is bundled with a Monit configuration monitoring low disk space watermark (<90%).
* If the `MONIT_SLACK_HOOK` is not set the Monit will not run