### PR TITLE
Read all needed parameters from _settings/LocalSettings.php file and use rotatelogs for Apche log files

### DIFF
--- a/DockerSettings.php
+++ b/DockerSettings.php
@@ -7,6 +7,8 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 
 const DOCKER_SKINS = [
 	'chameleon',
+	'CologneBlue',
+	'Modern',
 	'MonoBook', # bundled
 	'Refreshed',
 	'Timeless', # bundled
@@ -33,6 +35,7 @@ const DOCKER_EXTENSIONS = [
 	'CodeEditor', # bundled
 	'CodeMirror',
 	'Collection',
+	'CommentStreams',
 	'CommonsMetadata',
 //	'ConfirmAccount', no extension.json
 	'ConfirmEdit', # bundled
@@ -44,12 +47,19 @@ const DOCKER_EXTENSIONS = [
 	'Disambiguator',
 	'DisplayTitle',
 	'Echo',
+	'EditUser',
 	'EmbedVideo',
+	'EncryptedUploads',
+	'EventLogging',
 	'Favorites',
 	'Flow',
 	'Gadgets', # bundled
 //	'googleAnalytics',  no extension.json
+	'GoogleAnalyticsMetrics',
+	'GoogleDocCreator',
+	'GoogleDocTag',
 	'GTag',
+	'HeaderTabs',
 	'HeadScript',
 	'HTMLTags',
 	'IframePage',
@@ -66,8 +76,12 @@ const DOCKER_EXTENSIONS = [
 	'LookupUser',
 	'Loops',
 	'Maps',
+	'MassMessage',
+	'MassMessageEmail',
+	'MassPasswordReset',
 	'Math',
 	'MathJax',
+	'Mendeley',
 //	'MobileDetect', no extension.json
 	'MsUpload',
 	'MultimediaViewer', # bundled
@@ -86,33 +100,46 @@ const DOCKER_EXTENSIONS = [
 	'Renameuser', # bundled
 	'ReplaceText', # bundled
 	'RottenLinks',
-	'SkinPerNamespace',
-	'SkinPerPage',
+	'SaveSpinner',
+	'Scopus',
 	'Scribunto', # bundled
 	'SecureLinkFixer', # bundled
 //	'SelectCategory', no extension.json
+	'SemanticExternalQueryLookup',
 	'SemanticExtraSpecialProperties',
 	'SemanticCompoundQueries',
+	'SemanticDrilldown',
+//	'SemanticQueryInterface', no extension.json
 	'SemanticResultFormats',
 	'ShowMe',
 	'SimpleChanges',
 	'Skinny',
+	'SkinPerNamespace',
+	'SkinPerPage',
 //	'SocialProfile', no extension.json
 //	'SoundManager2Button', no extension.json
 	'SpamBlacklist', # bundled
+	'SRFEventCalendarMod',
 //	'Survey', no extension.json
+	'Sync',
 	'SyntaxHighlight_GeSHi', # bundled
+	'Tabber',
 	'Tabs',
 	'TemplateData', # bundled
 	'TemplateStyles',
 	'TextExtracts', # bundled
 	'Thanks',
 	'TimedMediaHandler',
+	'TinyMCE',
 	'TitleBlacklist', # bundled
 	'TwitterTag',
 	'UniversalLanguageSelector',
+	'UploadWizard',
+	'UploadWizardExtraButtons',
+	'UrlGetParameters',
 	'UserMerge',
 	'Variables',
+	'VEForAll',
 	'VisualEditor', # bundled
 	'VoteNY',
 	'Widgets',
@@ -163,7 +190,8 @@ $wgEnotifWatchlist = false; # UPO
 $wgEmailAuthentication = true;
 
 ## Database settings
-$wgDBtype = "mysql";
+$wgSQLiteDataDir = "$DOCKER_MW_VOLUME/sqlite";
+$wgDBtype = getenv( 'MW_DB_TYPE' );
 $wgDBserver = getenv( 'MW_DB_SERVER' );
 $wgDBname = getenv( 'MW_DB_NAME' );
 $wgDBuser = getenv( 'MW_DB_USER' );
@@ -409,7 +437,11 @@ if ( $tmpProxy ) {
 //}
 
 ######################### Custom Settings ##########################
-@include( 'CustomSettings.php' );
+if ( file_exists( "$IP/_settings/LocalSettings.php" ) ) {
+	require_once "$IP/_settings/LocalSettings.php";
+} elseif ( file_exists( "$IP/CustomSettings.php" ) ) {
+	require_once "$IP/CustomSettings.php";
+}
 
 # Flow https://www.mediawiki.org/wiki/Extension:Flow
 if ( isset( $dockerLoadExtensions['Flow'] ) ) {

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,17 +47,23 @@ RUN set -x; \
 	&& ln -s $MW_VOLUME/cache $MW_HOME/cache
 
 ### Skins
-# Chameleon
+# Chameleon skin
 RUN set -x; \
 	cd $MW_HOME/skins \
 	&& git clone https://github.com/ProfessionalWiki/chameleon.git \
 	&& cd chameleon \
 	&& git checkout -b $MW_VERSION c4cd43625c20e8979f2d274b4dd514388f3d47cc
 
-# Refreshed
+# CologneBlue, Modern, Refreshed skins
 RUN set -x; \
 	cd $MW_HOME/skins \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/skins/CologneBlue \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/skins/Modern \
 	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/skins/Refreshed
+
+RUN set -x; \
+	cd $MW_HOME/skins \
+	&& git clone --depth 1 -b v2.3.0 https://github.com/Hutchy68/pivot.git
 
 ### Extensions
 RUN set -x; \
@@ -117,7 +123,22 @@ RUN set -x; \
 	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/TemplateStyles \
 	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/LookupUser \
 	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/HeadScript \
-	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Favorites
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Favorites \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/GoogleDocTag \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/EditUser \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/EventLogging \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/EventStreamConfig \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/SaveSpinner \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/UploadWizard \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/CommentStreams \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/GoogleAnalyticsMetrics \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/MassMessage \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/MassMessageEmail \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticDrilldown \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/VEForAll \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/HeaderTabs \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/UrlGetParameters \
+	&& git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/TinyMCE
 
 # TODO move me above when REL1_35 branch will be created
 RUN set -x; \
@@ -125,6 +146,13 @@ RUN set -x; \
 	&& git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/LockAuthor \
 	&& cd LockAuthor \
 	&& git checkout -b $MW_VERSION ee5ab1ed2bc34ab1b08c799fb1e14e0d5de65953
+
+# TODO move me above when REL1_35 branch will be created
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/EncryptedUploads \
+	&& cd EncryptedUploads \
+	&& git checkout -b $MW_VERSION 51e3482462f1852e289d5863849b164e1b1a7ea9
 
 # TODO move me above, we use master because of compatibility issues of REL1_35 branch of the extension with core 1.35.1 tag
 RUN set -x; \
@@ -251,6 +279,69 @@ RUN set -x; \
 	&& cd WikiSEO \
 	&& git checkout -b $MW_VERSION 30bb8c323e8cd44df52c7537f97f8518de2557df
 
+# GoogleDocCreator
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://github.com/nischayn22/GoogleDocCreator.git \
+	&& cd GoogleDocCreator \
+	&& git checkout -b $MW_VERSION 63aecabb4292ad9d4e8336a93aec25f977ee633e
+
+# MassPasswordReset
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://github.com/nischayn22/MassPasswordReset.git \
+	&& cd MassPasswordReset \
+	&& git checkout -b $MW_VERSION affaeee6620f9a70b9dc80c53879a35c9aed92c6
+
+# Tabber
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://gitlab.com/hydrawiki/extensions/Tabber.git \
+	&& cd Tabber \
+	&& git checkout -b $MW_VERSION 6c67baf4d18518fa78e07add4c032d62dd384b06
+
+# UploadWizardExtraButtons
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://github.com/vedmaka/mediawiki-extension-UploadWizardExtraButtons.git UploadWizardExtraButtons \
+	&& cd UploadWizardExtraButtons \
+	&& git checkout -b $MW_VERSION accba1b9b6f50e67d709bd727c9f4ad6de78c0c0
+
+# Mendeley
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://github.com/nischayn22/Mendeley.git \
+	&& cd Mendeley \
+	&& git checkout -b $MW_VERSION b866c3608ada025ce8a3e161e4605cd9106056c4
+
+# Scopus
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://github.com/nischayn22/Scopus.git \
+	&& cd Scopus \
+	&& git checkout -b $MW_VERSION 4fe8048459d9189626d82d9d93a0d5f906c43746
+
+# SemanticQueryInterface
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://github.com/vedmaka/SemanticQueryInterface.git \
+	&& cd SemanticQueryInterface \
+	&& git checkout -b $MW_VERSION 0016305a95ecbb6ed4709bfa3fc6d9995d51336f
+
+# SRFEventCalendarMod
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://github.com/vedmaka/mediawiki-extension-SRFEventCalendarMod.git SRFEventCalendarMod \
+	&& cd SRFEventCalendarMod \
+	&& git checkout -b $MW_VERSION b029049ce32890eff03224b9e31c3bff11d9b6e1
+
+# Sync
+RUN set -x; \
+	cd $MW_HOME/extensions \
+	&& git clone https://github.com/nischayn22/Sync.git \
+	&& cd Sync \
+	&& git checkout -b $MW_VERSION f56b956521f383221737261ad68aef2367466b76
+
 # GTag1
 COPY sources/GTag1.2.0.tar.gz /tmp/
 RUN set -x; \
@@ -298,6 +389,7 @@ ENV MW_AUTOUPDATE=true \
 	MW_EMERGENCY_CONTACT=apache@invalid \
 	MW_PASSWORD_SENDER=apache@invalid \
 	MW_MAIN_CACHE_TYPE=CACHE_NONE \
+	MW_DB_TYPE=mysql \
 	MW_DB_SERVER=db \
 	MW_CIRRUS_SEARCH_SERVERS=elasticsearch \
 	MW_MAINTENANCE_CIRRUSSEARCH_UPDATECONFIG=1 \
@@ -316,7 +408,7 @@ COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY php_error_reporting.ini php_upload_max_filesize.ini /etc/php.d/
 COPY mediawiki.conf /etc/httpd/conf.d/
 COPY robots.txt .htaccess /var/www/html/
-COPY run-apache.sh mwjobrunner.sh mwsitemapgen.sh mwtranscoder.sh /
+COPY run-apache.sh mwjobrunner.sh mwsitemapgen.sh mwtranscoder.sh rotatelogs-compress.sh getMediawikiSettings.php /
 COPY DockerSettings.php $MW_HOME/DockerSettings.php
 
 # update packages every time!
@@ -326,8 +418,12 @@ RUN set -x; \
 	&& chmod -v +x /*.sh \
 	&& mkdir $MW_HOME/sitemap \
 	&& chown $WWW_USER:$WWW_GROUP $MW_HOME/sitemap \
-	&& chmod g+w $MW_HOME/sitemap
+	&& chmod g+w $MW_HOME/sitemap \
+	&& sed -i 's/^\(\s*ErrorLog .*\)/# \1/g' /etc/httpd/conf/httpd.conf \
+	&& sed -i 's/^\(\s*CustomLog .*\)/# \1/g' /etc/httpd/conf/httpd.conf
 
 CMD ["/run-apache.sh"]
 
 EXPOSE 80
+
+WORKDIR $MW_HOME

--- a/composer.local.json
+++ b/composer.local.json
@@ -6,6 +6,7 @@
 		"mediawiki/semantic-media-wiki": "3.2.3",
 		"mediawiki/semantic-result-formats": "3.2.0",
 		"mediawiki/semantic-compound-queries": "2.1.0",
+		"mediawiki/semantic-external-query-lookup": "1.x-dev",
 		"mediawiki/semantic-extra-special-properties": "2.1.0"
 	},
 	"extra": {

--- a/getMediawikiSettings.php
+++ b/getMediawikiSettings.php
@@ -1,0 +1,81 @@
+<?php
+
+use MediaWiki\MediaWikiServices;
+
+$mwHome = getenv( 'MW_HOME' );
+
+if ( !defined( 'MW_CONFIG_FILE' ) && !file_exists( "$mwHome/LocalSettings.php" ) ) {
+	define( 'MW_CONFIG_FILE', "$mwHome/DockerSettings.php" );
+}
+
+require_once "$mwHome/maintenance/Maintenance.php";
+
+class GetMediawikiSettings extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+		$this->addOption(
+			'variable',
+			'',
+			false,
+			true
+		);
+		$this->addOption(
+			'config',
+			'',
+			false,
+			true
+		);
+		$this->addOption(
+			'format',
+			'',
+			false,
+			true
+		);
+	}
+
+	public function execute() {
+	#	$this->output( "######\n" . var_export( $GLOBALS, true ) );
+
+		$return = null;
+		if ( $this->hasOption( 'config' ) ) {
+			$configName = $this->getOption( 'config' );
+			$config = MediaWikiServices::getInstance()->getMainConfig();
+			if ( $config->has( $configName ) ) {
+				$return = $config->get( $configName );
+			} // TODO else error message?
+		} elseif ( $this->hasOption( 'variable' ) ) {
+			$variableName = $this->getOption( 'variable' );
+			$return = $GLOBALS[$variableName] ?? '';
+		}
+
+		$format = $this->getOption( 'format', 'string' );
+		if ( strcasecmp( $format, 'json' ) === 0 ) {
+			$this->output( FormatJson::encode( $return ) );
+		} elseif ( $format === 'first' ) {
+			if ( is_array( $return ) && $return ) {
+				$return = array_values($return)[0];
+			}
+			$this->output( $return );
+		} else { // string
+			$this->output( $return );
+		}
+	}
+
+	public function getDbType() {
+		return Maintenance::DB_NONE;
+	}
+
+	public function finalSetup() {
+		global $wgShowExceptionDetails, $wgHooks;
+
+		$wgShowExceptionDetails = true;
+		$wgHooks['SetupAfterCache'][] = function () {
+			global $wgExtensionFunctions;
+			$wgExtensionFunctions = [];
+		};
+	}
+}
+
+$maintClass = GetMediawikiSettings::class;
+require RUN_MAINTENANCE_IF_MAIN;

--- a/mediawiki.conf
+++ b/mediawiki.conf
@@ -8,11 +8,13 @@ RedirectMatch 404 /\.git
 # Disable directory indexing
 Options -Indexes
 
+ErrorLog "|/usr/sbin/rotatelogs -c -f -l -p /rotatelogs-compress.sh -L /var/log/httpd/error_log /var/log/httpd/error_log.%Y%m%d 86400"
+
 # Overwrite log format to include X-Forwarded-For if it is provided
 <IfModule log_config_module>
 	SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 	LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 	LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" forwarded
-	CustomLog "logs/access_log" combined env=!forwarded
-	CustomLog "logs/access_log" forwarded env=forwarded
+	CustomLog "|/usr/sbin/rotatelogs -c -f -l -p /rotatelogs-compress.sh -L /var/log/httpd/access_log /var/log/httpd/access_log.%Y%m%d 86400" combined env=!forwarded
+	CustomLog "|/usr/sbin/rotatelogs -c -f -l -p /rotatelogs-compress.sh -L /var/log/httpd/access_log /var/log/httpd/access_log.%Y%m%d 86400" forwarded env=forwarded
 </IfModule>

--- a/mediawiki.conf
+++ b/mediawiki.conf
@@ -8,13 +8,13 @@ RedirectMatch 404 /\.git
 # Disable directory indexing
 Options -Indexes
 
-ErrorLog "|/usr/sbin/rotatelogs -c -f -l -p /rotatelogs-compress.sh -L /var/log/httpd/error_log /var/log/httpd/error_log.%Y%m%d 86400"
+ErrorLog "|/usr/sbin/rotatelogs -c -f -l -p /rotatelogs-compress.sh -L /var/log/httpd/error_log.current /var/log/httpd/error_log_%Y%m%d 86400"
 
 # Overwrite log format to include X-Forwarded-For if it is provided
 <IfModule log_config_module>
 	SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 	LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 	LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" forwarded
-	CustomLog "|/usr/sbin/rotatelogs -c -f -l -p /rotatelogs-compress.sh -L /var/log/httpd/access_log /var/log/httpd/access_log.%Y%m%d 86400" combined env=!forwarded
-	CustomLog "|/usr/sbin/rotatelogs -c -f -l -p /rotatelogs-compress.sh -L /var/log/httpd/access_log /var/log/httpd/access_log.%Y%m%d 86400" forwarded env=forwarded
+	CustomLog "|/usr/sbin/rotatelogs -c -f -l -p /rotatelogs-compress.sh -L /var/log/httpd/access_log.current /var/log/httpd/access_log_%Y%m%d 86400" combined env=!forwarded
+	CustomLog "|/usr/sbin/rotatelogs -c -f -l -p /rotatelogs-compress.sh -L /var/log/httpd/access_log.current /var/log/httpd/access_log_%Y%m%d 86400" forwarded env=forwarded
 </IfModule>

--- a/rotatelogs-compress.sh
+++ b/rotatelogs-compress.sh
@@ -3,15 +3,19 @@ file_to_compress="${2}"
 compress_exit_code=0
 
 if [[ "${file_to_compress}" ]]; then
-    echo "Compressing ${file_to_compress} ..."
-    tar --gzip --create --remove-files --transform 's/.*\///g' --file "${file_to_compress}.tar.gz" "${file_to_compress}"
+    if [[ -f  "${file_to_compress}" ]]; then
+        echo "Compressing ${file_to_compress} ..."
+        tar --gzip --create --remove-files --transform 's/.*\///g' --file "${file_to_compress}.tar.gz" "${file_to_compress}"
 
-    compress_exit_code=${?}
+        compress_exit_code=${?}
 
-    if [[ ${compress_exit_code} == 0 ]]; then
-        echo "File ${file_to_compress} was compressed."
+        if [[ ${compress_exit_code} == 0 ]]; then
+            echo "File ${file_to_compress} was compressed."
+        else
+            echo "Error compressing file ${file_to_compress} (tar exit code: ${compress_exit_code})."
+        fi
     else
-        echo "Error compressing file ${file_to_compress} (tar exit code: ${compress_exit_code})."
+        echo "File ${file_to_compress} does not exist".
     fi
 fi
 

--- a/rotatelogs-compress.sh
+++ b/rotatelogs-compress.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+file_to_compress="${2}"
+compress_exit_code=0
+
+if [[ "${file_to_compress}" ]]; then
+    echo "Compressing ${file_to_compress} ..."
+    tar --gzip --create --remove-files --transform 's/.*\///g' --file "${file_to_compress}.tar.gz" "${file_to_compress}"
+
+    compress_exit_code=${?}
+
+    if [[ ${compress_exit_code} == 0 ]]; then
+        echo "File ${file_to_compress} was compressed."
+    else
+        echo "Error compressing file ${file_to_compress} (tar exit code: ${compress_exit_code})."
+    fi
+fi
+
+exit ${compress_exit_code}


### PR DESCRIPTION
* it can use $IP/_settings/LocalSettings.php file ( we should mount `_settings` directory with `LocalSettings.php` file inside one, it allows to edit LocalSettings.php file using any text editor and changes will be synced with the docker image, old CustomSettings.php also supported still)
* it reads parameters from `LocalSettings.php` using `/getMediawikiSettings.php`,  (we don't need to define env variables in `docker-compose.yml` file, but they are supported still), so the `LocalSettings.php` file can looks like usual LocalSettings.php file and contain all needed parameters. 
* Added MW_DB_TYPE env variable which can be `sqlite` or `mysql`, sqlite can be used for CI tests (not tested yet)
* it uses rotatelogs for apache log files, it creates files `error_log_%Y%m%d` and `access_log_%Y%m%d`  and at midnight it will create a new ones. Also it creates `error_log.current` and `access_log.current` hardlinks to current log files, I added `.current` at the end because the hardlinks overwrites these files and we should not overwrite old log files when we run updated Docker container.