### PR TITLE
Change rewrite rule for w/rest.php path which can be used on wiki farms

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,7 +7,7 @@ RedirectMatch 404 /\.git
 Options -Indexes
 
 # VisualEditor support
-RewriteRule ^/?w/rest.php/ - [L,NC]
+RewriteRule /?w/rest.php/ - [L,NC]
 
 # Redirect / to Main Page
 RewriteRule ^/*$ %{DOCUMENT_ROOT}/w/index.php [L]


### PR DESCRIPTION
change rule to works on wiki farma where wiki placed in a subfolder
for example /somefolder/w/rest.php