### PR TITLE
Add delay before compressing log files and remove log files older 10 days

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -396,7 +396,9 @@ ENV MW_AUTOUPDATE=true \
 	MW_ENABLE_SITEMAP_GENERATOR=false \
 	MW_SITEMAP_PAUSE_DAYS=1 \
 	PHP_UPLOAD_MAX_FILESIZE=2M \
-	PHP_POST_MAX_SIZE=8M
+	PHP_POST_MAX_SIZE=8M \
+	LOG_FILES_COMPRESS_DELAY=3600 \
+	LOG_FILES_REMOVE_OLDER_THAN_DAYS=10
 
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY php_error_reporting.ini php_upload_max_filesize.ini /etc/php.d/

--- a/rotatelogs-compress.sh
+++ b/rotatelogs-compress.sh
@@ -3,9 +3,19 @@ file_to_compress="${2}"
 compress_exit_code=0
 
 if [[ "${file_to_compress}" ]]; then
+    # wait random number of seconds before compressing to avoid to compress log files simultaneously (especially for wiki farms)
+    if [ "$LOG_FILES_COMPRESS_DELAY" -eq 0 ]; then
+        DELAY=0
+    else
+        DELAY=$RANDOM
+        ((DELAY %= "$LOG_FILES_COMPRESS_DELAY"))
+    fi
+    echo "Wait for $DELAY seconds before compressing ${file_to_compress}"
+    sleep "$DELAY"
+
     if [[ -f  "${file_to_compress}" ]]; then
         echo "Compressing ${file_to_compress} ..."
-        tar --gzip --create --remove-files --transform 's/.*\///g' --file "${file_to_compress}.tar.gz" "${file_to_compress}"
+        tar --gzip --create --remove-files --absolute-names --transform 's/.*\///g' --file "${file_to_compress}.tar.gz" "${file_to_compress}"
 
         compress_exit_code=${?}
 
@@ -17,6 +27,15 @@ if [[ "${file_to_compress}" ]]; then
     else
         echo "File ${file_to_compress} does not exist".
     fi
+
+    # remove old log files
+    if [ -n "$LOG_FILES_REMOVE_OLDER_THAN_DAYS" ] && [ "$LOG_FILES_REMOVE_OLDER_THAN_DAYS" != false ]; then
+        LOG_DIRECTORY=$(dirname "${file_to_compress}")
+        find "$LOG_DIRECTORY" -type f -mtime "+$LOG_FILES_REMOVE_OLDER_THAN_DAYS" ! -iname ".*" ! -iname "*.current" -exec rm -f {} \;
+    fi
+
+    # compress uncompressed old log files
+    find "$LOG_DIRECTORY" -type f -mtime "+2" ! -iname ".*" ! -iname "*.current" ! -iname "*.gz" ! -iname "*.zip" -exec tar --gzip --create --remove-files --absolute-names --transform 's/.*\///g' --file {}.tar.gz {} \;
 fi
 
 exit ${compress_exit_code}


### PR DESCRIPTION
* it waits random number of seconds before start to compress log files,
  maximum number of seconds to wait defined in LOG_FILES_COMPRESS_DELAY
  by default it is 3600 seconds (1 hour)

* it removes log files older than 10 days
  (defined in LOG_FILES_REMOVE_OLDER_THAN_DAYS)