### PR TITLE
Don't allow to run the container if /mediawiki is not mounted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Depending on the setup approach the container will handle the settings files as 
 The container looks for a custom settings file at `_settings/LocalSettings.php` so
 you can mount the `_settings` directory to the container and put the `LocalSettings.php` file there.
 This file will be appended to the bottom of the `DockerSettings.php`
-
+.
 # Data (images, database)
 
 Data like uploaded images and the database files stored in the `_data` directory
@@ -353,7 +353,10 @@ Log files stored in `_logs` directory
 # Runtime directories structure
 
 * `/mediawiki` - the **volume** that stores `images`, `cache` and various extension persistent files like
-`compiled_templates` for `Widgets` or `config` files for SMW extension which are being symlinked into `/var/www/html/w`
+`compiled_templates` for `Widgets` or `config` files for SMW extension which are being symlinked into `/var/www/html/w`.
+  The volume **must** be mounted to persistent storage like a folder outside the docker container (`./_data/mediawiki` for example).
+  The container will not start if `/mediawiki` is not mounted to a folder, but if you know what you do,
+  you can allow to start the container without mounting `/mediawiki` if you set `MW_ALLOW_UNMOUNTED_VOLUME` environment variable as `true`.
 * `/mw_origin_files` - a temp/backup directory to toss some of original files and directories of the wiki core
 * `/var/www/html/w` - the main wiki web root
 * `/var/log/apache2` - logs for Apache web server

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Depending on the setup approach the container will handle the settings files as 
 The container looks for a custom settings file at `_settings/LocalSettings.php` so
 you can mount the `_settings` directory to the container and put the `LocalSettings.php` file there.
 This file will be appended to the bottom of the `DockerSettings.php`
-.
+
 # Data (images, database)
 
 Data like uploaded images and the database files stored in the `_data` directory

--- a/run-apache.sh
+++ b/run-apache.sh
@@ -4,7 +4,7 @@ set -x
 
 if ! mountpoint -q -- "$MW_VOLUME"; then
     echo "Folder $MW_VOLUME contains important data and must be mounted to persistent storage!"
-    if "$MW_ALLOW_UNMOUNTED_VOLUME" != true; then
+    if [ "$MW_ALLOW_UNMOUNTED_VOLUME" != true ]; then
         exit 1
     fi
 fi

--- a/run-apache.sh
+++ b/run-apache.sh
@@ -4,7 +4,7 @@ set -x
 
 if ! mountpoint -q -- "$MW_VOLUME"; then
     echo "Folder $MW_VOLUME contains important data and must be mounted to persistent storage!"
-    if "$MW_ALLOW_UNMOUNTED_VOLUME" !== true; then
+    if "$MW_ALLOW_UNMOUNTED_VOLUME" != true; then
         exit 1
     fi
 fi

--- a/run-apache.sh
+++ b/run-apache.sh
@@ -7,6 +7,7 @@ if ! mountpoint -q -- "$MW_VOLUME"; then
     if [ "$MW_ALLOW_UNMOUNTED_VOLUME" != true ]; then
         exit 1
     fi
+    echo "You allowed to continue because MW_ALLOW_UNMOUNTED_VOLUME is set as true"
 fi
 
 # read variables from LocalSettings.php

--- a/run-apache.sh
+++ b/run-apache.sh
@@ -2,6 +2,13 @@
 
 set -x
 
+if ! mountpoint -q -- "$MW_VOLUME"; then
+    echo "Folder $MW_VOLUME contains important data and must be mounted to persistent storage!"
+    if "$MW_ALLOW_UNMOUNTED_VOLUME" !== true; then
+        exit 1
+    fi
+fi
+
 # read variables from LocalSettings.php
 get_mediawiki_variable () {
     php /getMediawikiSettings.php --variable="$1" --format="${2:-string}"


### PR DESCRIPTION
You still can run it anyway if MW_ALLOW_UNMOUNTED_VOLUME set as true.