### PR TITLE
Make use of `gateway.docker.internal` to detect host address

### DIFF
--- a/DockerSettings.php
+++ b/DockerSettings.php
@@ -258,7 +258,8 @@ $wgRightsIcon = "";
 $wgDiff3 = "/usr/bin/diff3";
 
 # see https://www.mediawiki.org/wiki/Manual:$wgCdnServersNoPurge
-$wgCdnServersNoPurge = [ '172.16.0.0/12' ]; # Add docker network as CDN
+# Add docker networks as CDNs
+$wgCdnServersNoPurge = [ '172.16.0.0/12', '192.168.0.0/16', '10.0.0.0/8' ];
 
 if ( getenv( 'MW_SHOW_EXCEPTION_DETAILS' ) === 'true' ) {
 	$wgShowExceptionDetails = true;

--- a/conf/ssmtp.conf
+++ b/conf/ssmtp.conf
@@ -11,7 +11,7 @@ root=postmaster
 # The place where the mail goes. The actual machine name is required
 # no MX records are consulted. Commonly mailhosts are named mail.domain.com
 # The example will fit if you are in domain.com and your mailhub is so named.
-mailhub=172.17.0.1
+mailhub=DOCKER_GATEWAY
 
 # Example for SMTP port number 2525
 # mailhub=mail.your.domain:2525

--- a/conf/ssmtp.conf
+++ b/conf/ssmtp.conf
@@ -11,6 +11,7 @@ root=postmaster
 # The place where the mail goes. The actual machine name is required
 # no MX records are consulted. Commonly mailhosts are named mail.domain.com
 # The example will fit if you are in domain.com and your mailhub is so named.
+# /run-apache.sh script will replace DOCKER_GATEWAY with the docker gateway IP
 mailhub=DOCKER_GATEWAY
 
 # Example for SMTP port number 2525


### PR DESCRIPTION
* Updates `run-apache.sh` to use `gateway.docker.internal` as host address and fall back to `172.17.0.1` if not available
* Updates `ssmtp.conf` to contain replacement pattern to be processed via `run-apache.sh`
* Updates `$wgCdnServersNoPurge` to include all possible docker networks